### PR TITLE
Use io/wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+rvm:
+- 2.3.3
+- 2.5.0
+
+before_install:
+  - gem update --system # Due to: https://github.com/travis-ci/travis-ci/issues/8978
+
+cache: bundler
+
+# Travis permits the following phases: before_install, install, after_install, before_script, script, after_script
+# before_install:
+#   - gem update bundler # Travis RVM ships with an old-ish Bundler which has no install_if support
+
+script:
+  - bundle exec rspec --backtrace


### PR DESCRIPTION
fast_send was made in the days of Ruby 2.1. 2.3 introduced io.wait_writable/wait_readable which is just a thin bridge over to `rb_io_check_writable(fptr) + wait_for_single_fd(fptr, tv)`

See https://ruby-doc.org/stdlib-2.3.0/libdoc/io/wait/rdoc/IO.html#method-i-wait