### PR TITLE
Call cleanup even on closed socket

### DIFF
--- a/lib/fast_send/version.rb
+++ b/lib/fast_send/version.rb
@@ -1,3 +1,3 @@
 class FastSend
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
Previously calling the cleanup proc would not take place
if the socket entered the SocketHandler method in the closed
state. It does need to be called regardless, so the ensure()
travels to the method level.